### PR TITLE
Visualization Interface (fix JuliaPOMDP/POMDPs.jl#107)

### DIFF
--- a/docs/src/visualization.md
+++ b/docs/src/visualization.md
@@ -1,0 +1,23 @@
+# Visualization
+
+POMDPModelTools contains a basic visualization interface consisting of the `render` function.
+
+Problem writers should implement a method of this function so that their problem can be visualized in a variety of contexts including jupyter notebooks, 
+
+```@docs
+render
+```
+
+Sometimes it is important to have control over how the problem is rendered with different mimetypes. One way to handle this is to have render return a custom type, e.g.
+```julia
+struct MyProblemVisualization
+    mdp::MyProblem
+    step::NamedTuple
+end
+
+POMDPModelTools.render(mdp, step) = MyProblemVisualization(mdp, step)
+```
+and then implement custom `show` methods, e.g.
+```julia
+show(io::IO, mime::MIME"text/html", v::MyProblemVisualization)
+```

--- a/src/POMDPModelTools.jl
+++ b/src/POMDPModelTools.jl
@@ -14,6 +14,10 @@ import Random: rand, rand!
 import Statistics: mean
 import Base: ==
 
+export
+    render
+include("visualization.jl")
+
 # info interface
 export
     generate_sri,

--- a/src/visualization.jl
+++ b/src/visualization.jl
@@ -1,0 +1,48 @@
+"""
+    render(m::Union{MDP,POMDP}, step::NamedTuple)
+
+Return a renderable representation of the step in problem `m`.
+
+The renderable representation may be anything that has `show(io, mime, x)`
+methods. It could be a plot, svg, Compose.jl context, Cairo context, or image.
+
+# Arguments
+`step` is a `NamedTuple` that contains the states, action, etc. corresponding
+to one transition in a simulation. It may have the following fields:
+- `t`: the time step index
+- `s`: the state at the beginning of the step
+- `a`: the action
+- `sp`: the state at the end of the step (s')
+- `r`: the reward for the step
+- `o`: the observation
+- `b`: the belief at the 
+- `bp`: the belief at the end of the step
+- `i`: info from the model when the state transition was calculated
+- `ai`: info from the policy decision
+- `ui`: info from the belief update
+
+# Important Notes
+- `step` may not contain all of the elements listed above, so `render` should
+check for them and render only what is available
+- `o` typically corresponds to `sp`, so it is often be clearer for POMDPs to
+render `sp` rather than `s`.
+"""
+function render(m::Union{MDP,POMDP}, step)
+    @warn("No implementation of POMDPModelTools.render(m::$(typeof(m)), step) found. Falling back to text default.")
+    io = IOBuffer()
+    ioc = IOContext(io, :short=>true)
+    try
+        for (k, v) in pairs(step)
+            print(ioc, k)
+            print(ioc, ": ")
+            show(ioc, v)
+            println(ioc)
+        end
+    finally
+        println(ioc, """
+
+            Please implement POMDPModelTools.render(m::$(typeof(m)), step) to enable visualization.
+            """)
+    end
+    return String(take!(io))
+end

--- a/src/visualization.jl
+++ b/src/visualization.jl
@@ -21,28 +21,32 @@ to one transition in a simulation. It may have the following fields:
 - `ai`: info from the policy decision
 - `ui`: info from the belief update
 
+Keyword arguments are reserved for the problem implementer and can be used to control appearance, etc.
+
 # Important Notes
 - `step` may not contain all of the elements listed above, so `render` should
 check for them and render only what is available
 - `o` typically corresponds to `sp`, so it is often be clearer for POMDPs to
 render `sp` rather than `s`.
 """
-function render(m::Union{MDP,POMDP}, step)
-    @warn("No implementation of POMDPModelTools.render(m::$(typeof(m)), step) found. Falling back to text default.")
-    io = IOBuffer()
-    ioc = IOContext(io, :short=>true)
-    try
-        for (k, v) in pairs(step)
-            print(ioc, k)
-            print(ioc, ": ")
-            show(ioc, v)
-            println(ioc)
-        end
-    finally
-        println(ioc, """
+@generated function render(m::Union{MDP,POMDP}, step)
+    Core.println("WARNING: No implementation of POMDPModelTools.render(m::$m, step) found. Falling back to text default.")
+    return quote
+        io = IOBuffer()
+        ioc = IOContext(io, :short=>true)
+        try
+            for (k, v) in pairs(step)
+                print(ioc, k)
+                print(ioc, ": ")
+                show(ioc, v)
+                println(ioc)
+            end
+        finally
+            println(ioc, """
 
-            Please implement POMDPModelTools.render(m::$(typeof(m)), step) to enable visualization.
-            """)
+                Please implement POMDPModelTools.render(m::$(typeof(m)), step) to enable visualization.
+                """)
+        end
+        return String(take!(io))
     end
-    return String(take!(io))
 end

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,0 +1,2 @@
+POMDPModels
+POMDPSimulators

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,10 @@
 using POMDPModelTools
 using POMDPs
-# using POMDPModels
+using POMDPModels
 using Distributions
 using Random
 using Test
+using POMDPSimulators
 
 @testset "ordered" begin
     include("test_ordered_spaces.jl")
@@ -50,3 +51,7 @@ end
 #     include("test_fully_observable_pomdp.jl")
 #     include("test_underlying_mdp.jl")
 # end
+
+@testset "vis" begin
+    include("test_visualization.jl")
+end

--- a/test/test_visualization.jl
+++ b/test/test_visualization.jl
@@ -1,0 +1,6 @@
+m = BabyPOMDP()
+
+for step in stepthrough(m, Starve(), "s,a,o", max_steps=1)
+    gfx = render(m, step)
+    show(stdout, MIME("text/plain"), gfx)
+end


### PR DESCRIPTION
Alright, this is a small change, but I think it could have big consequences for how enjoyable this package is.

I'm pretty sure this is a good way to do it. An example is here https://github.com/JuliaPOMDP/POMDPModels.jl/blob/new_gridworld/src/gridworld_visualization.jl and here https://github.com/JuliaPOMDP/POMDPModels.jl/blob/new_gridworld/notebooks/GridWorld%20Visualization.ipynb with an example simulator that uses it here https://github.com/JuliaPOMDP/BlinkPOMDPSimulator.jl/blob/master/src/BlinkPOMDPSimulator.jl

fixes JuliaPOMDP/POMDPs.jl#107