### PR TITLE
remove default convenient implementations

### DIFF
--- a/docs/src/convenience.md
+++ b/docs/src/convenience.md
@@ -1,16 +1,5 @@
 # Convenience
 
-POMDPModelTools contains default implementations for some POMDPs.jl functions, including `actions`, `n_actions`, `action_index`, etc. for some obvious cases. This allows some obvious implementations to be skipped.
-
-For instance, if an MDP with a Bool action type is created, the obvious `actions` method is already implemented:
-
-```jldoctest
-julia> using POMDPs; using POMDPModelTools
-
-julia> struct BoolMDP <: MDP{Bool, Bool} end
-
-julia> actions(BoolMDP())
-(true, false)
-```
+POMDPModelTools contains default implementations for some POMDPs.jl functions.
 
 For a complete list of default implementations, see [convenient_implementations.jl](https://github.com/JuliaPOMDP/POMDPModelTools.jl/blob/master/src/convenient_implementations.jl) and [distributions_jl.jl](https://github.com/JuliaPOMDP/POMDPModelTools.jl/blob/master/src/distributions/distributions_jl.jl).

--- a/src/convenient_implementations.jl
+++ b/src/convenient_implementations.jl
@@ -1,13 +1,6 @@
 # some implementations for convenience
 # maintained by Zach Sunberg
 
-actions(mdp::MDP{S,Bool}) where S = (true, false)
-actions(mdp::MDP{S,Bool}, s::S, t::Tuple{Bool,Bool}=(true,false)) where S = (true,false)
-actions(mdp::POMDP{S,Bool,O}) where {S,O} = (true, false)
-actions(mdp::POMDP{S,Bool,O}, s::S, t::Tuple{Bool,Bool}=(true,false)) where {S,O} = (true,false)
-n_actions(mdp::MDP{S,Bool}) where S = 2
-n_actions(mdp::POMDP{S,Bool,O}) where {S, O} = 2
-
 rand(rng::AbstractRNG, t::Tuple{Bool, Bool}) = rand(rng, Bool)
 rand(t::Tuple{Bool, Bool}) = rand(Bool)
 
@@ -15,20 +8,3 @@ support(s::AbstractVector) = s
 support(s::Tuple) = s
 support(r::AbstractRange) = r
 support(g::Base.Generator) = g
-
-states(mdp::MDP{Bool}) = (true, false)
-states(mdp::POMDP{Bool}) = (true, false)
-n_states(mdp::MDP{Bool}) = 2
-n_states(mdp::POMDP{Bool}) = 2
-
-observations(::POMDP{S,A,Bool}) where {S,A} = (true,false)
-observations(::POMDP{S,A,Bool}, s::S) where {S,A} = (true,false)
-n_observations(::POMDP{S,A,Bool}) where {S,A} = 2
-
-stateindex(mdp::Union{MDP, POMDP}, s::Int) = s
-actionindex(mdp::Union{MDP, POMDP}, a::Int) = a
-obsindex(mdp::Union{MDP, POMDP}, o::Int) = o
-
-stateindex(mdp::Union{MDP, POMDP}, s::Bool) = s+1
-actionindex(mdp::Union{MDP, POMDP}, a::Bool) = a+1
-obsindex(mdp::Union{MDP, POMDP}, o::Bool) = o+1

--- a/test/test_implementations.jl
+++ b/test/test_implementations.jl
@@ -2,21 +2,21 @@ mutable struct TestMDP <: MDP{Bool, Bool} end
 mutable struct TestPOMDP <: POMDP{Bool, Bool, Bool} end
 
 let 
-    @test actions(TestMDP()) == (true, false)
-    @test actions(TestPOMDP()) == (true, false)
+    # @test actions(TestMDP()) == (true, false)
+    # @test actions(TestPOMDP()) == (true, false)
 
     a = [1,2,3]
     @test support(a) == a
     @test support((1,2,3)) == (1,2,3)
 
-    @test states(TestMDP()) == (true, false)
-    @test states(TestPOMDP()) == (true, false)
+    # @test states(TestMDP()) == (true, false)
+    # @test states(TestPOMDP()) == (true, false)
 
-    @test observations(TestPOMDP()) == (true, false)
-    @test n_observations(TestPOMDP()) == 2
+    # @test observations(TestPOMDP()) == (true, false)
+    # @test n_observations(TestPOMDP()) == 2
 
-    @test stateindex(TestMDP(), 1) == 1
-    @test actionindex(TestMDP(), 2) == 2
-    @test obsindex(TestMDP(), 3) == 3
+    # @test stateindex(TestMDP(), 1) == 1
+    # @test actionindex(TestMDP(), 2) == 2
+    # @test obsindex(TestMDP(), 3) == 3
 end
 

--- a/test/test_ordered_spaces.jl
+++ b/test/test_ordered_spaces.jl
@@ -1,9 +1,14 @@
 let
     struct TigerPOMDPTestFixture <: POMDP{Bool, Int, Bool} end
-
+    POMDPs.states(::TigerPOMDPTestFixture) = (true, false)
+    POMDPs.stateindex(::TigerPOMDPTestFixture, s) = Int(s) + 1
+    POMDPs.n_states(::TigerPOMDPTestFixture) = 2 
     POMDPs.actions(m::TigerPOMDPTestFixture) = 0:2
     POMDPs.n_actions(m::TigerPOMDPTestFixture) = 3
     POMDPs.actionindex(m::TigerPOMDPTestFixture, s::Int) = s+1
+    POMDPs.observations(::TigerPOMDPTestFixture) = (true, false)
+    POMDPs.obsindex(::TigerPOMDPTestFixture, o) = Int(o) + 1
+    POMDPs.n_observations(::TigerPOMDPTestFixture) = 2
 
     pomdp = TigerPOMDPTestFixture()
 
@@ -15,12 +20,14 @@ end
 struct TM <: POMDP{Int, Int, Int} end
 POMDPs.states(::TM) = [1,3]
 POMDPs.n_states(::TM) = 2
+POMDPs.stateindex(::TM, s::Int) = s
 
 @test_throws ErrorException ordered_states(TM())
 
 struct TM2 <: POMDP{Int, Int, Int} end
 POMDPs.states(::TM2) = [1,3]
 POMDPs.n_states(::TM2) = 3
+POMDPs.stateindex(::TM2, s::Int) = s
 
 println("There should be a warning below:")
 ordered_states(TM2())


### PR DESCRIPTION

This PR addresses JuliaPOMDP/POMDPs.jl#223

Docs have been updated as well. 

A PR in POMDPModels should follow. 

It might be a duplicate of #11 