### PR TITLE
Constraint Distributions.jl version

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
 julia 0.7
-Distributions 
+Distributions 0.11 0.17
 POMDPs


### PR DESCRIPTION
The [0.17 release of `Distributions.jl`](https://github.com/JuliaStats/Distributions.jl/releases/tag/v0.17.0) is not compatible with `POMDPModelTools.jl`. Thus, for now I just constrained the version. Next, one should address #13 