### PR TITLE
Use @test_logs to check for warnings

### DIFF
--- a/test/test_ordered_spaces.jl
+++ b/test/test_ordered_spaces.jl
@@ -29,5 +29,4 @@ POMDPs.states(::TM2) = [1,3]
 POMDPs.n_states(::TM2) = 3
 POMDPs.stateindex(::TM2, s::Int) = s
 
-println("There should be a warning below:")
-ordered_states(TM2())
+@test_logs (:warn,) ordered_states(TM2())


### PR DESCRIPTION
Stumbled across this when implementing #15. Thus, this does not  touch `test_distributions_jl.jl`.

If #15 is not merged, `test_distributions_jl.jl` should also be modified.