### PR TITLE
sparse observation matrix bugfix

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,7 +6,6 @@ version = "0.2.1"
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-POMDPModels = "355abbd5-f08e-5560-ac9e-8b5f2592a0ca"
 POMDPs = "a93abf59-7444-517b-a68a-c42f96afdd7d"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "POMDPModelTools"
 uuid = "08074719-1b2a-587c-a292-00f91cc44415"
 authors = ["JuliaPOMDP Contributors"]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"

--- a/Project.toml
+++ b/Project.toml
@@ -14,13 +14,12 @@ UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"
 
 [compat]
 Distributions = ">= 0.17"
-POMDPs = "0.7.3, 0.8.0"
 POMDPModels = ">= 0.4.2"
+POMDPs = "0.7.3, 0.8.0"
 julia = "1"
 
 [extras]
 BeliefUpdaters = "8bb6e9a1-7d73-552c-a44a-e5dc5634aac4"
-DiscreteValueIteration = "4b033969-44f6-5439-a48b-c11fa3648068"
 POMDPModels = "355abbd5-f08e-5560-ac9e-8b5f2592a0ca"
 POMDPPolicies = "182e52fb-cfd0-5e46-8c26-fd0667c990f4"
 POMDPSimulators = "e0d0a172-29c6-5d4e-96d0-f262df5d01fd"
@@ -28,4 +27,4 @@ Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "DiscreteValueIteration", "POMDPModels", "POMDPSimulators", "POMDPPolicies", "BeliefUpdaters", "Pkg"]
+test = ["Test", "POMDPModels", "POMDPSimulators", "POMDPPolicies", "BeliefUpdaters", "Pkg"]

--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.2.1"
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+POMDPModels = "355abbd5-f08e-5560-ac9e-8b5f2592a0ca"
 POMDPs = "a93abf59-7444-517b-a68a-c42f96afdd7d"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
@@ -14,7 +15,7 @@ UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"
 
 [compat]
 Distributions = ">= 0.17"
-POMDPModels = ">= 0.4.2"
+POMDPModels = ">= 0.4.3"
 POMDPs = "0.7.3, 0.8.0"
 julia = "1"
 

--- a/Project.toml
+++ b/Project.toml
@@ -4,8 +4,11 @@ authors = ["JuliaPOMDP Contributors"]
 version = "0.2.1"
 
 [deps]
+Compose = "a81c6b42-2e10-5240-aca2-a61377ecd94b"
+DiscreteValueIteration = "4b033969-44f6-5439-a48b-c11fa3648068"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+POMDPModels = "355abbd5-f08e-5560-ac9e-8b5f2592a0ca"
 POMDPs = "a93abf59-7444-517b-a68a-c42f96afdd7d"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ authors = ["JuliaPOMDP Contributors"]
 version = "0.2.1"
 
 [deps]
-Compose = "a81c6b42-2e10-5240-aca2-a61377ecd94b"
 DiscreteValueIteration = "4b033969-44f6-5439-a48b-c11fa3648068"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/Project.toml
+++ b/Project.toml
@@ -4,10 +4,8 @@ authors = ["JuliaPOMDP Contributors"]
 version = "0.2.1"
 
 [deps]
-DiscreteValueIteration = "4b033969-44f6-5439-a48b-c11fa3648068"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-POMDPModels = "355abbd5-f08e-5560-ac9e-8b5f2592a0ca"
 POMDPs = "a93abf59-7444-517b-a68a-c42f96afdd7d"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
@@ -17,10 +15,12 @@ UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"
 [compat]
 Distributions = ">= 0.17"
 POMDPs = "0.7.3, 0.8.0"
+POMDPModels = ">= 0.4.2"
 julia = "1"
 
 [extras]
 BeliefUpdaters = "8bb6e9a1-7d73-552c-a44a-e5dc5634aac4"
+DiscreteValueIteration = "4b033969-44f6-5439-a48b-c11fa3648068"
 POMDPModels = "355abbd5-f08e-5560-ac9e-8b5f2592a0ca"
 POMDPPolicies = "182e52fb-cfd0-5e46-8c26-fd0667c990f4"
 POMDPSimulators = "e0d0a172-29c6-5d4e-96d0-f262df5d01fd"
@@ -28,4 +28,4 @@ Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "POMDPModels", "POMDPSimulators", "POMDPPolicies", "BeliefUpdaters", "Pkg"]
+test = ["Test", "DiscreteValueIteration", "POMDPModels", "POMDPSimulators", "POMDPPolicies", "BeliefUpdaters", "Pkg"]

--- a/src/sparse_tabular.jl
+++ b/src/sparse_tabular.jl
@@ -171,11 +171,11 @@ function transition_matrix_a_s_sp(mdp::Union{MDP, POMDP})
         si = stateindex(mdp, s)
         for a in actions(mdp, s)
             ai = actionindex(mdp, a)
-            if isterminal(mdp, s) # if terminal, there is a probability of 1 of staying in that state
-                push!(transmat_row_A[ai], si)
-                push!(transmat_col_A[ai], si)
-                push!(transmat_data_A[ai], 1.0)
-            else
+            # if isterminal(mdp, s) # if terminal, there is a probability of 1 of staying in that state
+            #     push!(transmat_row_A[ai], si)
+            #     push!(transmat_col_A[ai], si)
+            #     push!(transmat_data_A[ai], 1.0)
+            # else
                 td = transition(mdp, s, a)
                 for (sp, p) in weighted_iterator(td)
                     if p > 0.0
@@ -185,7 +185,7 @@ function transition_matrix_a_s_sp(mdp::Union{MDP, POMDP})
                         push!(transmat_data_A[ai], p)
                     end
                 end
-            end
+            # end
         end
     end
     transmats_A_S_S2 = [sparse(transmat_row_A[a], transmat_col_A[a], transmat_data_A[a], ns, ns) for a in 1:na]
@@ -199,9 +199,9 @@ function reward_s_a(mdp::Union{MDP, POMDP})
     action_space = actions(mdp)
     reward_S_A = fill(-Inf, (length(state_space), length(action_space))) # set reward for all actions to -Inf unless they are in actions(mdp, s)
     for s in state_space
-        if isterminal(mdp, s)
-            reward_S_A[stateindex(mdp, s), :] .= 0.0
-        else
+        # if isterminal(mdp, s)
+        #     reward_S_A[stateindex(mdp, s), :] .= 0.0
+        # else
             for a in actions(mdp, s)
                 td = transition(mdp, s, a)
                 r = 0.0
@@ -212,7 +212,7 @@ function reward_s_a(mdp::Union{MDP, POMDP})
                 end
                 reward_S_A[stateindex(mdp, s), actionindex(mdp, a)] = r
             end
-        end
+        # end
     end
     return reward_S_A
 end

--- a/src/sparse_tabular.jl
+++ b/src/sparse_tabular.jl
@@ -163,11 +163,11 @@ function transition_matrix_a_s_sp(mdp::Union{MDP, POMDP})
     na = length(actions(mdp))
     state_space = states(mdp)
     ns = length(state_space)
-    transmat_row_A = [Int[] for _ in 1:n_actions(mdp)]
-    transmat_col_A = [Int[] for _ in 1:n_actions(mdp)]
-    transmat_data_A = [Float64[] for _ in 1:n_actions(mdp)]
+    transmat_row_A = [Int64[] for _ in 1:na]
+    transmat_col_A = [Int64[] for _ in 1:na]
+    transmat_data_A = [Float64[] for _ in 1:na]
 
-    for s in states(mdp)
+    for s in state_space
         si = stateindex(mdp, s)
         for a in actions(mdp, s)
             ai = actionindex(mdp, a)
@@ -230,19 +230,15 @@ function terminal_states_set(mdp::Union{MDP, POMDP})
 end
 
 function observation_matrix_a_sp_o(pomdp::POMDP)
-    state_space = states(pomdp)
-    action_space = actions(pomdp)
-    obs_space = observations(pomdp)
-    na = length(action_space)
-    ns = length(state_space)
-    no = length(obs_space)
-    obsmat_row_A = [Int[] for _ in 1:na]
-    obsmat_col_A = [Int[] for _ in 1:na]
+    state_space, action_space, obs_space = states(pomdp), actions(pomdp), observations(pomdp)
+    na, ns, no = length(action_space), length(state_space), length(obs_space)
+    obsmat_row_A = [Int64[] for _ in 1:na]
+    obsmat_col_A = [Int64[] for _ in 1:na]
     obsmat_data_A = [Float64[] for _ in 1:na]
 
-    for sp in states(pomdp)
+    for sp in state_space
         spi = stateindex(pomdp, sp)
-        for a in actions(pomdp)
+        for a in action_space
             ai = actionindex(pomdp, a)
             od = observation(pomdp, a, sp)
             for (o, p) in weighted_iterator(od)
@@ -255,8 +251,8 @@ function observation_matrix_a_sp_o(pomdp::POMDP)
             end
         end
     end
-    obsmats_A_SP_O = [sparse(obsmat_row_A[a], obsmat_col_A[a], obsmat_data_A[a], ns, ns) for a in 1:na]
-    @assert all(all(sum(obsmats_A_SP_O[a], dims=2) .≈ ones(no)) for a in 1:na) "Observation probabilities must sum to 1"
+    obsmats_A_SP_O = [sparse(obsmat_row_A[a], obsmat_col_A[a], obsmat_data_A[a], ns, no) for a in 1:na]
+    @assert all(all(sum(obsmats_A_SP_O[a], dims=2) .≈ ones(ns)) for a in 1:na) "Observation probabilities must sum to 1"
     return obsmats_A_SP_O
 end
 

--- a/src/sparse_tabular.jl
+++ b/src/sparse_tabular.jl
@@ -171,11 +171,11 @@ function transition_matrix_a_s_sp(mdp::Union{MDP, POMDP})
         si = stateindex(mdp, s)
         for a in actions(mdp, s)
             ai = actionindex(mdp, a)
-            # if isterminal(mdp, s) # if terminal, there is a probability of 1 of staying in that state
-            #     push!(transmat_row_A[ai], si)
-            #     push!(transmat_col_A[ai], si)
-            #     push!(transmat_data_A[ai], 1.0)
-            # else
+            if isterminal(mdp, s) # if terminal, there is a probability of 1 of staying in that state
+                push!(transmat_row_A[ai], si)
+                push!(transmat_col_A[ai], si)
+                push!(transmat_data_A[ai], 1.0)
+            else
                 td = transition(mdp, s, a)
                 for (sp, p) in weighted_iterator(td)
                     if p > 0.0
@@ -185,7 +185,7 @@ function transition_matrix_a_s_sp(mdp::Union{MDP, POMDP})
                         push!(transmat_data_A[ai], p)
                     end
                 end
-            # end
+            end
         end
     end
     transmats_A_S_S2 = [sparse(transmat_row_A[a], transmat_col_A[a], transmat_data_A[a], ns, ns) for a in 1:na]
@@ -199,9 +199,9 @@ function reward_s_a(mdp::Union{MDP, POMDP})
     action_space = actions(mdp)
     reward_S_A = fill(-Inf, (length(state_space), length(action_space))) # set reward for all actions to -Inf unless they are in actions(mdp, s)
     for s in state_space
-        # if isterminal(mdp, s)
-        #     reward_S_A[stateindex(mdp, s), :] .= 0.0
-        # else
+        if isterminal(mdp, s)
+            reward_S_A[stateindex(mdp, s), :] .= 0.0
+        else
             for a in actions(mdp, s)
                 td = transition(mdp, s, a)
                 r = 0.0
@@ -212,7 +212,7 @@ function reward_s_a(mdp::Union{MDP, POMDP})
                 end
                 reward_S_A[stateindex(mdp, s), actionindex(mdp, a)] = r
             end
-        # end
+        end
     end
     return reward_S_A
 end

--- a/test/test_info.jl
+++ b/test/test_info.jl
@@ -27,7 +27,11 @@ let
     @test :info in nodenames(DDNStructure(mdp))
     s = initialstate(mdp, rng)
     a = rand(rng, actions(mdp))
-    sp, r, i = @inferred gen(DDNOut(:sp,:r,:info), mdp, s, a, rng)
+    if VERSION >= v"1.3"
+        sp, r, i = @inferred gen(DDNOut(:sp,:r,:info), mdp, s, a, rng)
+    else
+        sp, r, i = gen(DDNOut(:sp,:r,:info), mdp, s, a, rng)
+    end
     @test i === nothing
 
     pomdp = TigerPOMDP()
@@ -35,7 +39,11 @@ let
     @test :info in nodenames(DDNStructure(pomdp))
     s = initialstate(pomdp, rng)
     a = rand(rng, actions(pomdp))
-    sp, o, r, i = @inferred gen(DDNOut(:sp,:o,:r,:info), pomdp, s, a, rng)
+    if VERSION >= v"1.3"
+        sp, o, r, i = @inferred gen(DDNOut(:sp,:o,:r,:info), pomdp, s, a, rng)
+    else
+        sp, o, r, i = gen(DDNOut(:sp,:o,:r,:info), pomdp, s, a, rng)
+    end
     @test i === nothing
 
     up = VoidUpdater()

--- a/test/test_tabular.jl
+++ b/test/test_tabular.jl
@@ -21,14 +21,18 @@ function test_reward(pb1::Union{MDP, POMDP}, pb2::Union{SparseTabularMDP, Sparse
             si = stateindex(pb1, s)
             for a in actions(pb1)
                 ai = actionindex(pb1, a)
-                td = transition(pb1, s, a)
-                r_pb1 = 0.0
-                for (sp, p) in weighted_iterator(td)
-                    if p > 0.0
-                        r_pb1 += p*reward(pb1, s, a, sp)
+                if isterminal(pb1, s)
+                    @test reward(pb2, si, ai) == 0.0
+                else
+                    td = transition(pb1, s, a)
+                    r_pb1 = 0.0
+                    for (sp, p) in weighted_iterator(td)
+                        if p > 0.0
+                            r_pb1 += p*reward(pb1, s, a, sp)
+                        end
                     end
+                    @test r_pb1 ≈ reward(pb2, si, ai)
                 end
-                @test r_pb1 ≈ reward(pb2, si, ai)
             end
         end
     end

--- a/test/test_tabular.jl
+++ b/test/test_tabular.jl
@@ -1,38 +1,51 @@
 function test_transition(pb1::Union{MDP, POMDP}, pb2::Union{SparseTabularMDP, SparseTabularPOMDP})
-    for s in states(pb1)
-        for a in actions(pb1)
-            td1 = transition(pb1, s, a)
+    @testset "transition" begin
+        for s in states(pb1)
             si = stateindex(pb1, s)
-            ai = actionindex(pb1, a)
-            td2 = transition(pb2, si, ai)
-            for (sp, p) in weighted_iterator(td1)
-                spi = stateindex(pb1, sp)
-                @test pdf(td2, spi) == p
+            for a in actions(pb1)
+                ai = actionindex(pb1, a)
+                td1 = transition(pb1, s, a)
+                td2 = transition(pb2, si, ai)
+                for (sp, p) in weighted_iterator(td1)
+                    spi = stateindex(pb1, sp)
+                    @test pdf(td2, spi) == p
+                end
             end
         end
     end
 end
 
 function test_reward(pb1::Union{MDP, POMDP}, pb2::Union{SparseTabularMDP, SparseTabularPOMDP})
-    for s in states(pb1)
-        for a in actions(pb1)
+    @testset "reward" begin
+        for s in states(pb1)
             si = stateindex(pb1, s)
-            ai = actionindex(pb1, a)
-            @test reward(pb1, s, a) == reward(pb2, si, ai)
+            for a in actions(pb1)
+                ai = actionindex(pb1, a)
+                td = transition(pb1, s, a)
+                r_pb1 = 0.0
+                for (sp, p) in weighted_iterator(td)
+                    if p > 0.0
+                        r_pb1 += p*reward(pb1, s, a, sp)
+                    end
+                end
+                @test r_pb1 ≈ reward(pb2, si, ai)
+            end
         end
     end
 end
 
 function test_observation(pb1::POMDP, pb2::SparseTabularPOMDP)
-    for s in states(pb1)
-        for a in actions(pb1)
-            od1 = observation(pb1, a, s)
-            si = stateindex(pb1, s)
-            ai = actionindex(pb1, a)
-            od2 = observation(pb2, ai, si)
-            for (o, p) in weighted_iterator(od1)
-                oi = obsindex(pb1, o)
-                @test pdf(od2, oi) == p
+    @testset "transitions" begin
+        for s in states(pb1)
+            for a in actions(pb1)
+                od1 = observation(pb1, a, s)
+                si = stateindex(pb1, s)
+                ai = actionindex(pb1, a)
+                od2 = observation(pb2, ai, si)
+                for (o, p) in weighted_iterator(od1)
+                    oi = obsindex(pb1, o)
+                    @test pdf(od2, oi) == p
+                end
             end
         end
     end
@@ -40,6 +53,8 @@ end
 
 
 ## MDP 
+
+@testset "Random MDP" begin
 
 mdp = RandomMDP(100, 4, 0.95)
 
@@ -71,46 +86,58 @@ sparsegw = SparseTabularMDP(gw)
 @inferred actions(sparsegw, 101)
 @test actions(sparsegw, 101) == collect(actions(sparsegw))
 
+end
+
+
 ## POMDP 
 
-pomdp = TigerPOMDP()
+function test_pomdp(pomdp::POMDP)
+    @show_requirements SparseTabularPOMDP(pomdp)
 
-@show_requirements SparseTabularPOMDP(pomdp)
+    rand_mdp = RandomMDP(100, 4, 0.95)
 
-spomdp = SparseTabularPOMDP(pomdp)
+    spomdp = SparseTabularPOMDP(pomdp)
 
-spomdp2 = SparseTabularPOMDP(spomdp)
+    @testset "generic" begin
+        spomdp2 = SparseTabularPOMDP(spomdp)
 
-@test spomdp2.T == spomdp.T
-@test spomdp2.R == spomdp.R
-@test spomdp2.O == spomdp.O
-@test spomdp2.discount == spomdp.discount
+        @test spomdp2.T == spomdp.T
+        @test spomdp2.R == spomdp.R
+        @test spomdp2.O == spomdp.O
+        @test spomdp2.discount == spomdp.discount
 
-spomdp3 = SparseTabularPOMDP(spomdp, reward = zeros(length(states(mdp)), length(actions(mdp))))
-@test spomdp3.T == spomdp.T
-@test spomdp3.R != spomdp.R
-spomdp3 = SparseTabularPOMDP(spomdp, transition = [sparse(1:length(states(mdp)), 1:length(states(mdp)), 1.0) for a in 1:length(actions(mdp))])
-@test spomdp3.T != spomdp.T
-@test spomdp3.R == spomdp.R
-spomdp3 = SparseTabularPOMDP(spomdp, discount = 0.5)
-@test spomdp3.discount != spomdp.discount
-@test size(observation_matrix(spomdp, 1)) == (length(states(spomdp)), length(observations(spomdp)))
-@test observation_matrices(spomdp) == spomdp2.O
-@test transition_matrices(spomdp) == spomdp2.T
-@test reward_matrix(spomdp) == spomdp2.R
+        spomdp3 = SparseTabularPOMDP(spomdp, reward = zeros(length(states(rand_mdp)), length(actions(rand_mdp))))
+        @test spomdp3.T == spomdp.T
+        @test spomdp3.R != spomdp.R
+        spomdp3 = SparseTabularPOMDP(spomdp, transition = [sparse(1:length(states(rand_mdp)), 1:length(states(rand_mdp)), 1.0) for a in 1:length(actions(rand_mdp))])
+        @test spomdp3.T != spomdp.T
+        @test spomdp3.R == spomdp.R
+        spomdp3 = SparseTabularPOMDP(spomdp, discount = 0.5)
+        @test spomdp3.discount != spomdp.discount
+        @test size(observation_matrix(spomdp, 1)) == (length(states(spomdp)), length(observations(spomdp)))
+        @show size(observation_matrix(spomdp, 1)) == (length(states(spomdp)), length(observations(spomdp)))
+        @test observation_matrices(spomdp) == spomdp2.O
+        @test transition_matrices(spomdp) == spomdp2.T
+        @test reward_matrix(spomdp) == spomdp2.R
 
-## Tests 
+        @test length(states(pomdp)) == length(states(spomdp))
+        @test length(actions(pomdp)) == length(actions(spomdp))
+        @test length(observations(pomdp)) == length(observations(spomdp))
+        @test statetype(spomdp) == Int64
+        @test actiontype(spomdp) == Int64
+        @test obstype(spomdp) == Int64
+        @test discount(spomdp) == discount(pomdp)
+        @test length(spomdp.terminal_states) == length([s for s in states(pomdp) if isterminal(pomdp, s)])
+    end
 
-@test length(states(pomdp)) == length(states(spomdp))
-@test length(actions(pomdp)) == length(actions(spomdp))
-@test length(observations(pomdp)) == length(observations(spomdp))
-@test statetype(spomdp) == Int64
-@test actiontype(spomdp) == Int64
-@test obstype(spomdp) == Int64
-@test discount(spomdp) == discount(pomdp)
-@test isempty(spomdp.terminal_states)
+    test_transition(pomdp, spomdp)
+    test_reward(pomdp, spomdp)
+    test_observation(pomdp, spomdp)
+end
 
-test_transition(mdp, smdp)
-test_transition(pomdp, spomdp)
-test_reward(pomdp, spomdp)
-test_observation(pomdp, spomdp)
+@testset "Tiger POMDP" begin
+    test_pomdp(TigerPOMDP())
+end
+@testset "TMaze POMDP" begin
+    test_pomdp(TMaze())
+end


### PR DESCRIPTION
The dimensions of the constructed sparse observation matrix were wrong (ns x ns). Fixed this (-> ns x no) and a few other things on the way.

PS: I thought i was working on my private fork and pushed the changes, realized after I was in the SISL repo. I reverted that commit and am now submitting the same changes as a PR here. Apologies for that